### PR TITLE
refactor: Route path 상수화

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,13 @@ import { BrowserRouter, Route, Routes } from "react-router";
 import { PhotoBoothProvider } from "./contexts/PhotoBoothProvider";
 import MainLayout from "./layouts/MainLayout";
 import Start from "./pages/Start";
-import FrameType from "./pages/FrameType";
+import FrameTypeSelect from "./pages/FrameTypeSelect";
 import PhotoShoot from "./pages/PhotoShoot";
+import PhotoSelect from "./pages/PhotoSelect";
 import Print from "./pages/Print";
 import PrintProgress from "./pages/PrintProgress";
 import Share from "./pages/Share";
-
-import PhotoSelect from "./pages/PhotoSelect";
+import { FRAME_TYPE_SELECT, PHOTO_SELECT, PHOTO_SHOOT, PRINT, PRINT_PROGRESS, SHARE } from "./constants/routes";
 
 function App() {
     return (
@@ -17,15 +17,12 @@ function App() {
                 <Routes>
                     <Route element={<MainLayout />}>
                         <Route index element={<Start />} />
-                        <Route path="/frame-type" element={<FrameType />} />
-                        <Route path="/photo-shoot" element={<PhotoShoot />} />
-                        <Route path="/photo-select" element={<PhotoSelect />} />
-                        <Route path="/print" element={<Print />} />
-                        <Route
-                            path="/print-progress"
-                            element={<PrintProgress />}
-                        />
-                        <Route path="/share/:id" element={<Share />} />
+                        <Route path={FRAME_TYPE_SELECT} element={<FrameTypeSelect />} />
+                        <Route path={PHOTO_SHOOT} element={<PhotoShoot />} />
+                        <Route path={PHOTO_SELECT} element={<PhotoSelect />} />
+                        <Route path={PRINT} element={<Print />} />
+                        <Route path={PRINT_PROGRESS} element={<PrintProgress />} />
+                        <Route path={`${SHARE}/:id`} element={<Share />} />
                     </Route>
                 </Routes>
             </BrowserRouter>

--- a/src/constants/routes.tsx
+++ b/src/constants/routes.tsx
@@ -1,0 +1,6 @@
+export const FRAME_TYPE_SELECT = "/frame-type-select";
+export const PHOTO_SHOOT = "/photo-shoot";
+export const PHOTO_SELECT = "/photo-select";
+export const PRINT = "/print";
+export const PRINT_PROGRESS = "/print-progress";
+export const SHARE = "/share";

--- a/src/pages/FrameTypeSelect.tsx
+++ b/src/pages/FrameTypeSelect.tsx
@@ -5,8 +5,9 @@ import PhotoFrame from "../components/PhotoFrame";
 import { usePhotoBooth } from "../hooks/usePhotoBooth";
 import type { FrameType } from "../types/FrameType";
 import { useNavigate } from "react-router";
+import { PHOTO_SHOOT } from "../constants/routes";
 
-export default function FrameType() {
+export default function FrameTypeSelect() {
     const { frameType, setFrameType } = usePhotoBooth();
     const navigate = useNavigate();
 
@@ -19,19 +20,19 @@ export default function FrameType() {
     }, [frameType]);
 
     return (
-        <div className="flex flex-col w-full h-full items-center">
+        <div className="flex flex-col w-full h-full items-center gap-6">
             <Heading>가로 / 세로 프레임 선택</Heading>
             <div className="flex grow gap-32 items-center">
                 <div className="flex flex-col items-center gap-6 p-8 hover:bg-primary-100 data-[active=true]:bg-primary-100 rounded-lg cursor-pointer" onClick={() => handleFrameTypeClick("landscape")} data-active={frameType === "landscape"}>
-                    <PhotoFrame frameType="landscape" className="h-96" />
+                    <PhotoFrame frameType="landscape" />
                     <span className="text-lg font-semibold">가로 프레임</span>
                 </div>
                 <div className="flex flex-col items-center gap-6 p-8 hover:bg-primary-100 data-[active=true]:bg-primary-100 rounded-lg cursor-pointer" onClick={() => handleFrameTypeClick("portrait")} data-active={frameType === "portrait"}>
-                    <PhotoFrame frameType="portrait" className="h-96" />
+                    <PhotoFrame frameType="portrait" />
                     <span className="text-lg font-semibold">세로 프레임</span>
                 </div>
             </div>
-            <Button size="lg" onClick={() => navigate("/photo-shoot")} disabled={!frameType}>선택 완료</Button>
+            <Button size="lg" onClick={() => navigate(PHOTO_SHOOT)} disabled={!frameType}>선택 완료</Button>
         </div>
     );
 }

--- a/src/pages/PhotoSelect.tsx
+++ b/src/pages/PhotoSelect.tsx
@@ -4,6 +4,7 @@ import Heading from "../components/Heading";
 import PhotoFrame from "../components/PhotoFrame";
 import { usePhotoBooth } from "../hooks/usePhotoBooth";
 import { useMemo, useEffect } from "react";
+import { PRINT } from "../constants/routes";
 
 const PHOTO_SELECT_LIMIT = 4;
 
@@ -52,11 +53,7 @@ export default function PhotoSelect() {
             <Heading>사진을 선택해주세요</Heading>
             <div className="flex w-full justify-center mt-10">
                 <div className="mx-auto my-auto ml-20">
-                    <PhotoFrame
-                        frameType="landscape"
-                        className="h-[72vh]"
-                        photos={selectedPhotos}
-                    />
+                    <PhotoFrame frameType="landscape" photos={selectedPhotos} />
                 </div>
                 <div className="w-[70%] my-auto mx-auto mr-20">
                     {photoUrls.length > 0 && (
@@ -83,7 +80,7 @@ export default function PhotoSelect() {
                     )}
                 </div>
             </div>
-            <Button size="lg" onClick={() => navigate("/print")} disabled={selectedPhotos.length < PHOTO_SELECT_LIMIT}>선택 완료</Button>
+            <Button size="lg" onClick={() => navigate(PRINT)} disabled={selectedPhotos.length < PHOTO_SELECT_LIMIT}>선택 완료</Button>
         </div>
     );
 }

--- a/src/pages/PhotoShoot.tsx
+++ b/src/pages/PhotoShoot.tsx
@@ -2,6 +2,7 @@ import Heading from "../components/Heading";
 import { useEffect, useRef, useState } from "react";
 import { usePhotoBooth } from "../hooks/usePhotoBooth";
 import { useNavigate } from "react-router";
+import { PHOTO_SELECT } from "../constants/routes";
 
 const TOTAL_SHOTS = 8;
 const SHOOT_INTERVAL = 7000;
@@ -41,7 +42,7 @@ export default function PhotoShoot() {
                         if (newCount >= TOTAL_SHOTS) {
                             clearInterval(timer);
                             stopCamera();
-                            setTimeout(() => navigate("/photo-select"), 500);
+                            setTimeout(() => navigate(PHOTO_SELECT), 500);
                         }
                         return newCount;
                     });

--- a/src/pages/Print.tsx
+++ b/src/pages/Print.tsx
@@ -3,6 +3,7 @@ import Button from "../components/Button";
 import Heading from "../components/Heading";
 import { usePhotoBooth } from "../hooks/usePhotoBooth";
 import { useNavigate } from "react-router";
+import { PRINT_PROGRESS } from "../constants/routes";
 
 const MAX_PRINT_COUNT = 4;
 
@@ -49,7 +50,7 @@ export default function Print() {
                     <span className="text-lg font-semibold">방명록에 등록하기</span>
                 </label>
             </div>
-            <Button size="lg" onClick={() => navigate("/print-progress")}>출력하기</Button>
+            <Button size="lg" onClick={() => navigate(PRINT_PROGRESS)}>출력하기</Button>
         </div>
     );
 }

--- a/src/pages/Start.tsx
+++ b/src/pages/Start.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "react-router";
 import Heading from "../components/Heading";
 import Button from "../components/Button";
+import { FRAME_TYPE_SELECT } from "../constants/routes";
 
 export default function Start() {
     const navigate = useNavigate();
@@ -8,7 +9,7 @@ export default function Start() {
     return (
         <div className="flex flex-col w-full h-full py-12 items-center justify-around">
             <Heading>로고 영역</Heading>
-            <Button size="lg" onClick={() => navigate("/frame-type")}>시작하기</Button>
+            <Button size="lg" onClick={() => navigate(FRAME_TYPE_SELECT)}>시작하기</Button>
         </div>
     );
 }


### PR DESCRIPTION
반복적으로 사용되는 Route path에 대해 별도의 상수로 분리했습니다.

+ `FrameType` 타입과 페이지 네이밍이 같아 혼동이 있어 페이지 네이밍의 경우 `FrameTypeSelect`로 변경했습니다.