### PR TITLE
Feat/deactivate4x6 frame

### DIFF
--- a/src/pages/FrameTypeSelect.tsx
+++ b/src/pages/FrameTypeSelect.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import Button from "../components/Button";
 import Heading from "../components/Heading";
 import PhotoFrame from "../components/PhotoFrame";


### PR DESCRIPTION
## 구현 기능
- 4x6 프레임 비활성화 및 흐리게 처리
- 2x6 클릭 시 흐리게 + 체크 이모지 추가

## 작업 내용

위 구현 기능을 하고 나니 이슈가 생겼습니다.
기존에는 다른 프레임을 선택하면 그때 `setFrameType(frameType);`을 통해서  프레임 상태를 변환하고 그러면서 자연스럽게 선택 되었던 프레임이어도 다른 프레임을 선택하면 자연스레 프레임 선택이 취소가 되는 구조였습니다.
하지만 프레임을 하나로 고정해버리니 선택할 다른 프레임이 없어서 한번 클릭하면 어딜 클릭하든 선택 취소가 안되게 됐고 진행상의 문제는 없으나 UX적으로 좋지 못하고 생각해서 이에 대해 한번 더 클릭하면 선택 취소가 되도록 수정했습니다.

## 비디오뷰
1. 기존 방식대로

https://github.com/user-attachments/assets/230f5eca-6f37-462a-9c82-8baeebecbe5b

2. 클릭 시 취소되도록 수정

https://github.com/user-attachments/assets/420a3691-ee3b-4eda-8e70-666c0f2ff5dd

+ 3. 4x6에 대해 글씨 추가
<img width="1501" height="775" alt="image" src="https://github.com/user-attachments/assets/2f326fc8-53fd-4f1a-8e22-6bea2f2a972f" />

## 바라는 점
1, 2, 3에 대해 괜찮은지
